### PR TITLE
Add DB user management and registration UI

### DIFF
--- a/ihj-backend/auth.py
+++ b/ihj-backend/auth.py
@@ -1,34 +1,39 @@
 from datetime import datetime, timedelta
 from typing import Optional
+import secrets
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-import yaml
-from yaml.loader import SafeLoader
+from sqlalchemy.orm import Session
+
 from config import settings
-from models import TokenData, User
+from models import TokenData, User, UserCreate, PasswordRecoveryRequest, PasswordResetRequest
+from database_postgresql import SessionLocal, engine, Base
+from db_models import UserORM
+
+# Garantir que as tabelas existam
+Base.metadata.create_all(bind=engine)
 
 # Configuração de criptografia
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 security = HTTPBearer()
 
-# Carregamento das credenciais do arquivo config.yaml
-def load_user_credentials():
-    """Carrega as credenciais dos usuários do arquivo config.yaml"""
+# Utilidades de banco de dados
+def get_db():
+    db = SessionLocal()
     try:
-        with open('config.yaml', 'r', encoding='utf-8') as file:
-            config = yaml.load(file, Loader=SafeLoader)
-            return config.get('credentials', {}).get('usernames', {})
-    except FileNotFoundError:
-        # Retorna usuários padrão se o arquivo não existir
-        return {
-            "admin": {
-                "name": "Administrador",
-                "password": "$2b$12$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW",  # secret
-                "email": "admin@ihj.com"
-            }
-        }
+        yield db
+    finally:
+        db.close()
+
+
+def get_user_by_username(db: Session, username: str) -> Optional[UserORM]:
+    return db.query(UserORM).filter(UserORM.username == username).first()
+
+
+def get_user_by_email(db: Session, email: str) -> Optional[UserORM]:
+    return db.query(UserORM).filter(UserORM.email == email).first()
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verifica se a senha está correta"""
@@ -39,21 +44,21 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 def authenticate_user(username: str, password: str) -> Optional[User]:
-    """Autentica um usuário"""
-    users = load_user_credentials()
-    
-    if username not in users:
-        return None
-    
-    user_data = users[username]
-    if not verify_password(password, user_data["password"]):
-        return None
-    
-    return User(
-        username=username,
-        name=user_data["name"],
-        email=user_data.get("email")
-    )
+    """Autentica um usuário no banco de dados"""
+    with SessionLocal() as db:
+        user_db = get_user_by_username(db, username)
+        if not user_db:
+            return None
+
+        if not verify_password(password, user_db.hashed_password):
+            return None
+
+        return User(
+            username=user_db.username,
+            name=user_db.name,
+            email=user_db.email,
+            access_level=user_db.access_level,
+        )
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     """Cria um token de acesso JWT"""
@@ -84,14 +89,71 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
     except JWTError:
         raise credentials_exception
     
-    users = load_user_credentials()
-    if token_data.username not in users:
-        raise credentials_exception
-    
-    user_data = users[token_data.username]
-    return User(
-        username=token_data.username,
-        name=user_data["name"],
-        email=user_data.get("email")
-    )
+    with SessionLocal() as db:
+        user_db = get_user_by_username(db, token_data.username)
+        if not user_db:
+            raise credentials_exception
+
+        return User(
+            username=user_db.username,
+            name=user_db.name,
+            email=user_db.email,
+            access_level=user_db.access_level,
+        )
+
+
+def create_user(user: UserCreate) -> User:
+    """Cria um novo usuário no banco"""
+    with SessionLocal() as db:
+        if get_user_by_username(db, user.username) or get_user_by_email(db, user.email):
+            raise HTTPException(status_code=400, detail="Usuário já existe")
+
+        new_user = UserORM(
+            name=user.name,
+            username=user.username,
+            email=user.email,
+            hashed_password=get_password_hash(user.password),
+            access_level=user.access_level,
+        )
+        db.add(new_user)
+        db.commit()
+        db.refresh(new_user)
+        return User(
+            username=new_user.username,
+            name=new_user.name,
+            email=new_user.email,
+            access_level=new_user.access_level,
+        )
+
+
+def generate_password_recovery(email: str) -> str:
+    """Gera token de recuperação de senha"""
+    with SessionLocal() as db:
+        user_db = get_user_by_email(db, email)
+        if not user_db:
+            raise HTTPException(status_code=404, detail="Usuário não encontrado")
+
+        token = secrets.token_urlsafe(32)
+        user_db.reset_token = token
+        user_db.reset_expiration = datetime.utcnow() + timedelta(hours=1)
+        db.commit()
+        return token
+
+
+def reset_password(token: str, new_password: str) -> None:
+    """Altera a senha utilizando o token de recuperação"""
+    with SessionLocal() as db:
+        user_db = (
+            db.query(UserORM)
+            .filter(UserORM.reset_token == token, UserORM.reset_expiration > datetime.utcnow())
+            .first()
+        )
+
+        if not user_db:
+            raise HTTPException(status_code=400, detail="Token inválido ou expirado")
+
+        user_db.hashed_password = get_password_hash(new_password)
+        user_db.reset_token = None
+        user_db.reset_expiration = None
+        db.commit()
 

--- a/ihj-backend/db_models.py
+++ b/ihj-backend/db_models.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.sql import func
+from database_postgresql import Base
+
+class UserORM(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+    username = Column(String(50), unique=True, nullable=False, index=True)
+    email = Column(String(100), unique=True, nullable=False, index=True)
+    hashed_password = Column(String(200), nullable=False)
+    access_level = Column(String(50), nullable=False, server_default='user')
+    reset_token = Column(String(200), nullable=True, index=True)
+    reset_expiration = Column(DateTime, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/ihj-backend/main.py
+++ b/ihj-backend/main.py
@@ -6,7 +6,14 @@ import uvicorn
 
 from config import settings
 from models import *
-from auth import authenticate_user, create_access_token, get_current_user
+from auth import (
+    authenticate_user,
+    create_access_token,
+    get_current_user,
+    create_user,
+    generate_password_recovery,
+    reset_password,
+)
 from services import equipamento_service, similaridade_service
 
 # Criação da aplicação FastAPI
@@ -52,6 +59,28 @@ async def login(user_credentials: UserLogin):
     )
     
     return Token(access_token=access_token, token_type="bearer")
+
+
+@app.post("/auth/register", response_model=MessageResponse)
+async def register(user: UserCreate):
+    """Endpoint para registrar um novo usuário"""
+    created = create_user(user)
+    return MessageResponse(message=f"Usuário {created.name} criado com sucesso")
+
+
+@app.post("/auth/recover", response_model=MessageResponse)
+async def recover_password(request: PasswordRecoveryRequest):
+    """Endpoint para solicitar recuperação de senha"""
+    token = generate_password_recovery(request.email)
+    # Em uma aplicação real, este token seria enviado por e-mail
+    return MessageResponse(message=f"Token de recuperação: {token}")
+
+
+@app.post("/auth/reset", response_model=MessageResponse)
+async def reset_password_endpoint(request: PasswordResetRequest):
+    """Endpoint para redefinir senha usando token"""
+    reset_password(request.token, request.new_password)
+    return MessageResponse(message="Senha atualizada com sucesso")
 
 @app.post("/auth/logout", response_model=MessageResponse)
 async def logout(current_user: User = Depends(get_current_user)):

--- a/ihj-backend/models.py
+++ b/ihj-backend/models.py
@@ -18,6 +18,22 @@ class User(BaseModel):
     username: str
     name: str
     email: Optional[str] = None
+    access_level: str
+
+# Models for user creation and password recovery
+class UserCreate(BaseModel):
+    name: str
+    email: str
+    username: str
+    password: str
+    access_level: str = "user"
+
+class PasswordRecoveryRequest(BaseModel):
+    email: str
+
+class PasswordResetRequest(BaseModel):
+    token: str
+    new_password: str
 
 # Modelos para busca de equipamentos
 class ClasseResponse(BaseModel):

--- a/ihj-frontend/src/App.jsx
+++ b/ihj-frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import LoginForm from './components/LoginForm';
+import RegisterForm from './components/RegisterForm';
 import Layout from './components/Layout';
 import Dashboard from './components/Dashboard';
 import BuscaCaracteristicas from './components/BuscaCaracteristicas';
@@ -25,11 +26,15 @@ function App() {
       <Router>
         <Routes>
           {/* Rota de login */}
-          <Route 
-            path="/login" 
+          <Route
+            path="/login"
             element={
               isAuthenticated() ? <Navigate to="/dashboard" replace /> : <LoginForm />
-            } 
+            }
+          />
+          <Route
+            path="/register"
+            element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <RegisterForm />}
           />
           
           {/* Rotas protegidas */}

--- a/ihj-frontend/src/components/LoginForm.jsx
+++ b/ihj-frontend/src/components/LoginForm.jsx
@@ -116,12 +116,11 @@ export default function LoginForm() {
                 )}
               </Button>
             </form>
-            
-            <div className="mt-4 text-sm text-gray-600">
-              {/*
-              <p><strong>Usuários de teste:</strong></p>
-              <p>admin / secret</p>
-              <p>user1 / secret</p>*/}
+
+            <div className="mt-4 text-sm text-gray-600 text-center">
+              <a href="/register" className="text-blue-600 hover:underline">
+                Não possui conta? Cadastre-se
+              </a>
             </div>
           </CardContent>
         </Card>

--- a/ihj-frontend/src/components/RegisterForm.jsx
+++ b/ihj-frontend/src/components/RegisterForm.jsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Loader2, UserPlus } from 'lucide-react';
+import { authAPI } from '@/lib/api';
+
+export default function RegisterForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [accessLevel, setAccessLevel] = useState('user');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      await authAPI.register({ name, email, username, password, access_level: accessLevel });
+      navigate('/login');
+    } catch (err) {
+      console.error('Erro no cadastro:', err);
+      setError('Não foi possível realizar o cadastro.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <div className="flex justify-center">
+            <UserPlus className="h-12 w-12 text-blue-600" />
+          </div>
+          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">Cadastro de Usuário</h2>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Novo Usuário</CardTitle>
+            <CardDescription>Preencha os dados para criar sua conta</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {error && (
+                <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="name">Nome</Label>
+                <Input id="name" type="text" value={name} onChange={(e) => setName(e.target.value)} required disabled={loading} />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required disabled={loading} />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="username">Usuário</Label>
+                <Input id="username" type="text" value={username} onChange={(e) => setUsername(e.target.value)} required disabled={loading} />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Senha</Label>
+                <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required disabled={loading} />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="accessLevel">Nível de Acesso</Label>
+                <select
+                  id="accessLevel"
+                  className="w-full border rounded px-2 py-1"
+                  value={accessLevel}
+                  onChange={(e) => setAccessLevel(e.target.value)}
+                  disabled={loading}
+                >
+                  <option value="user">Usuário</option>
+                  <option value="admin">Administrador</option>
+                </select>
+              </div>
+
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Salvando...
+                  </>
+                ) : (
+                  'Cadastrar'
+                )}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/ihj-frontend/src/lib/api.js
+++ b/ihj-frontend/src/lib/api.js
@@ -49,6 +49,21 @@ export const authAPI = {
     const response = await api.post('/auth/login', { username, password });
     return response.data;
   },
+
+  register: async (data) => {
+    const response = await api.post('/auth/register', data);
+    return response.data;
+  },
+
+  recoverPassword: async (email) => {
+    const response = await api.post('/auth/recover', { email });
+    return response.data;
+  },
+
+  resetPassword: async (token, newPassword) => {
+    const response = await api.post('/auth/reset', { token, new_password: newPassword });
+    return response.data;
+  },
   
   logout: async () => {
     const response = await api.post('/auth/logout');

--- a/init-db/01-create-tables.sql
+++ b/init-db/01-create-tables.sql
@@ -34,6 +34,22 @@ CREATE INDEX IF NOT EXISTS idx_equipamentos_classe ON equipamentos(classe);
 CREATE INDEX IF NOT EXISTS idx_caracteristicas_equipamento_id ON caracteristicas(equipamento_id);
 CREATE INDEX IF NOT EXISTS idx_caracteristicas_nome ON caracteristicas(nome_caracteristica);
 
+-- Criar tabela de usuários
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    hashed_password VARCHAR(200) NOT NULL,
+    access_level VARCHAR(50) NOT NULL DEFAULT 'user',
+    reset_token VARCHAR(200),
+    reset_expiration TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+
 -- Inserir dados de exemplo (baseados no arquivo original)
 INSERT INTO equipamentos (equipamento, localizacao, denominacao_localizacao, material, classe) VALUES
 ('MTE01241', 'LOC001', 'Área de Produção 1', 'Bomba Centrífuga', 'Bombas'),


### PR DESCRIPTION
## Summary
- create SQLAlchemy `UserORM` and update DB init script
- switch auth to read/write users in the database
- add user registration and password recovery endpoints
- implement frontend register form and routing
- expose new auth functions in frontend API
- add link to register from login page
- include new `access_level` field for users

## Testing
- `python3 ihj-backend/test_backend.py` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6886a92f64bc832684e4be41c62ce470