### PR TITLE
Restrict registration to admin users

### DIFF
--- a/ihj-backend/main.py
+++ b/ihj-backend/main.py
@@ -62,8 +62,17 @@ async def login(user_credentials: UserLogin):
 
 
 @app.post("/auth/register", response_model=MessageResponse)
-async def register(user: UserCreate):
+async def register(
+    user: UserCreate,
+    current_user: User = Depends(get_current_user)
+):
     """Endpoint para registrar um novo usuário"""
+    if current_user.access_level != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Apenas administradores podem criar novos usuários",
+        )
+
     created = create_user(user)
     return MessageResponse(message=f"Usuário {created.name} criado com sucesso")
 

--- a/ihj-frontend/src/App.jsx
+++ b/ihj-frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Dashboard from './components/Dashboard';
 import BuscaCaracteristicas from './components/BuscaCaracteristicas';
 import AnaliseSimilaridade from './components/AnaliseSimilaridade';
 import ProtectedRoute from './components/ProtectedRoute';
+import AdminRoute from './components/AdminRoute';
 import { isAuthenticated } from './lib/auth';
 import './App.css';
 
@@ -34,7 +35,11 @@ function App() {
           />
           <Route
             path="/register"
-            element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <RegisterForm />}
+            element={
+              <AdminRoute>
+                <RegisterForm />
+              </AdminRoute>
+            }
           />
           
           {/* Rotas protegidas */}

--- a/ihj-frontend/src/components/AdminRoute.jsx
+++ b/ihj-frontend/src/components/AdminRoute.jsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { isAuthenticated, getUserInfo } from '@/lib/auth';
+
+export default function AdminRoute({ children }) {
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const user = getUserInfo();
+  if (!user || user.access_level !== 'admin') {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return children;
+}

--- a/ihj-frontend/src/components/Layout.jsx
+++ b/ihj-frontend/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Search, BarChart3, LogOut, Menu, X } from 'lucide-react';
+import { Search, BarChart3, LogOut, Menu, X, UserPlus } from 'lucide-react';
 import { getUserInfo, logout } from '@/lib/auth';
 
 export default function Layout() {
@@ -15,7 +15,7 @@ export default function Layout() {
     logout();
   };
 
-  const navigation = [
+  const baseNavigation = [
     {
       name: 'Busca por Características',
       href: '/dashboard/caracteristicas',
@@ -29,6 +29,19 @@ export default function Layout() {
       current: location.pathname === '/dashboard/similaridade'
     }
   ];
+
+  const adminNavigation = [
+    {
+      name: 'Cadastrar Usuário',
+      href: '/register',
+      icon: UserPlus,
+      current: location.pathname === '/register'
+    }
+  ];
+
+  const navigation = userInfo?.access_level === 'admin'
+    ? [...baseNavigation, ...adminNavigation]
+    : baseNavigation;
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/ihj-frontend/src/components/LoginForm.jsx
+++ b/ihj-frontend/src/components/LoginForm.jsx
@@ -117,11 +117,6 @@ export default function LoginForm() {
               </Button>
             </form>
 
-            <div className="mt-4 text-sm text-gray-600 text-center">
-              <a href="/register" className="text-blue-600 hover:underline">
-                Não possui conta? Cadastre-se
-              </a>
-            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- limit user creation to accounts with admin access
- hide registration link in the login screen
- add AdminRoute component to handle admin-only pages
- expose admin-only registration route in React app
- show registration link in the sidebar only for admins

## Testing
- `python3 test_backend.py` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6886b1ed8934832691c1bf750c23c02f