### PR TITLE
Fix similarity analysis to use characteristic names

### DIFF
--- a/ihj-backend/services.py
+++ b/ihj-backend/services.py
@@ -294,9 +294,9 @@ class SimilaridadeService:
             
             # Cria pivot table
             df_pivot = df_global.pivot_table(
-                index=['equipamento', 'centro', 'classe'], 
-                columns='id_caracteristica', 
-                values='valor', 
+                index=['equipamento', 'centro', 'classe'],
+                columns='ds_caracteristica',
+                values='valor',
                 aggfunc='first'
             )
             df_reset = df_pivot.reset_index()
@@ -321,7 +321,7 @@ class SimilaridadeService:
                     "equipamento": row['equipamento'],
                     "similarity_score": float(row['Similarity_Score']),
                     "centro": row.get('centro'),
-                    "classe": row.get('Classe')
+                    "classe": row.get('classe')
                 })
             
             # Prepara detalhes completos


### PR DESCRIPTION
## Summary
- use `ds_caracteristica` when pivoting data for similarity comparison
- return equipment class using correct column name

## Testing
- `cd ihj-backend && pytest -q || true`

------
https://chatgpt.com/codex/tasks/task_e_689e19813f888326ab2648b0a5ef93d7